### PR TITLE
Align Text type with current API schema

### DIFF
--- a/src/Corpus.tsx
+++ b/src/Corpus.tsx
@@ -92,7 +92,7 @@ export default function Corpus({ id }: Props) {
         },
         cell: (info) => (
           <div>
-            {info.row.original.authors.map(({ name, ref }) => (
+            {info.row.original.authors?.map(({ name, ref }) => (
               <div key={name}>
                 <span>{name}</span>
                 <br />
@@ -112,10 +112,10 @@ export default function Corpus({ id }: Props) {
         ),
       },
       {
-        accessorKey: 'dates',
+        accessorKey: 'referenceYear',
         header: 'Year',
-        accessorFn: (row) => row.dates?.yearNormalized.toString() || '',
-        cell: (info) => <span>{info.row.original.dates?.yearNormalized}</span>,
+        accessorFn: (row) => row.referenceYear || '',
+        cell: (info) => <span>{info.row.original.referenceYear}</span>,
       },
       {
         accessorKey: 'chapters',

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,28 +9,45 @@ export interface Author {
   ref?: string;
 }
 
+export interface SourceLink {
+  url: string;
+  text?: string;
+}
+
+export interface Source {
+  bibl: string;
+  type?: string;
+  title?: string;
+  author?: string;
+  publisher?: string;
+  year?: string;
+  placePublished?: string;
+  links?: SourceLink[];
+}
+
 export interface Text {
   id: string;
   name: string;
-  authors: Author[];
+  corpus: string;
   title: string;
-  source: string;
-  sourceUrl: string;
-  dates?: {
-    yearNormalized: string;
-    yearWritten?: string;
-    yearPrinted?: string;
+  authors?: Author[];
+  ref?: string;
+  refs?: string[];
+  sources?: Source[];
+  commit?: string;
+  referenceYear?: string;
+  metrics: {
+    biodiversityIndex?: number;
+    numOfAnimals?: number;
+    numOfChapters?: number;
+    numOfEntities?: number;
+    numOfEntityTypes?: number;
+    numOfParagraphs?: number;
+    numOfPlants?: number;
+    numOfWords?: number;
   };
-  metrics?: {
-    biodiversityIndex: number;
-    numOfAnimals: number;
-    numOfChapters: number;
-    numOfEntities: number;
-    numOfEntityTypes: number;
-    numOfParagraphs: number;
-    numOfPlants: number;
-    numOfWords: number;
-  };
+  corpusUrl: string;
+  entitiesUrl: string;
 }
 
 export interface CorpusMetrics {


### PR DESCRIPTION
- Replace the legacy `source`, `sourceUrl`, and `dates` fields on the `Text` interface with the structured `Source`/`SourceLink` types and `referenceYear` from the current EcoCor OpenAPI spec (api.yaml).
- Add missing fields: `corpus`, `corpusUrl`, `entitiesUrl`, `ref`, `refs`, `commit`
- Update Corpus.tsx to read `referenceYear` instead of the removed `dates.yearNormalized` for the year column

resolve #24
 